### PR TITLE
Split big index.js file into multiple smaller files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
 repos:
   # Autoformat: Python code, syntax patterns are modernized
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.14.0
     hooks:
       - id: pyupgrade
         args:
@@ -19,7 +19,7 @@ repos:
 
   # Autoformat: Python code
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
         # args are not passed, but see the config in pyproject.toml

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -556,7 +556,7 @@ class BinderHub(Application):
         return os.environ.get("BUILD_NAMESPACE", "default")
 
     build_image = Unicode(
-        "quay.io/jupyterhub/repo2docker:2022.10.0",
+        "quay.io/jupyterhub/repo2docker:2023.06.0",
         help="""
         DEPRECATED: Use c.KubernetesBuildExecutor.build_image
 

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -16,7 +16,7 @@ import kubernetes.config
 from kubernetes import client, watch
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
-from traitlets import Any, Bool, Dict, Integer, Unicode, default
+from traitlets import Any, Bool, Dict, Integer, List, Unicode, default
 from traitlets.config import LoggingConfigurable
 
 from .utils import KUBE_REQUEST_TIMEOUT, ByteSpecification, rendezvous_rank
@@ -125,6 +125,15 @@ class BuildExecutor(LoggingConfigurable):
         config=True,
     )
 
+    repo2docker_extra_args = List(
+        Unicode,
+        default_value=[],
+        help="""
+        Extra commandline parameters to be passed to jupyter-repo2docker during build
+        """,
+        config=True,
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.main_loop = IOLoop.current()
@@ -155,6 +164,8 @@ class BuildExecutor(LoggingConfigurable):
         if self.memory_limit:
             r2d_options.append("--build-memory-limit")
             r2d_options.append(str(self.memory_limit))
+
+        r2d_options += self.repo2docker_extra_args
 
         return r2d_options
 

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -277,7 +277,7 @@ class KubernetesBuildExecutor(BuildExecutor):
         return os.getenv("BUILD_NAMESPACE", "default")
 
     build_image = Unicode(
-        "quay.io/jupyterhub/repo2docker:2022.10.0",
+        "quay.io/jupyterhub/repo2docker:2023.06.0",
         help="Docker image containing repo2docker that is used to spawn the build pods.",
         config=True,
     )

--- a/binderhub/static/js/src/constants.js
+++ b/binderhub/static/js/src/constants.js
@@ -1,0 +1,3 @@
+
+export const BASE_URL = $('#base-url').data().url;
+export const BADGE_BASE_URL = $('#badge-base-url').data().url;

--- a/binderhub/static/js/src/form.js
+++ b/binderhub/static/js/src/form.js
@@ -1,0 +1,30 @@
+import { getPathType } from './path';
+
+
+export function getBuildFormValues() {
+  const providerPrefix = $('#provider_prefix').val().trim();
+  let repo = $('#repository').val().trim();
+  if (providerPrefix !== 'git') {
+    repo = repo.replace(/^(https?:\/\/)?gist.github.com\//, '');
+    repo = repo.replace(/^(https?:\/\/)?github.com\//, '');
+    repo = repo.replace(/^(https?:\/\/)?gitlab.com\//, '');
+  }
+  // trim trailing or leading '/' on repo
+  repo = repo.replace(/(^\/)|(\/?$)/g, '');
+  // git providers encode the URL of the git repository as the repo
+  // argument.
+  if (repo.includes("://") || providerPrefix === 'gl') {
+    repo = encodeURIComponent(repo);
+  }
+
+  let ref = $('#ref').val().trim() || $("#ref").attr("placeholder");
+  if (providerPrefix === 'zenodo' || providerPrefix === 'figshare' || providerPrefix === 'dataverse' ||
+    providerPrefix === 'hydroshare') {
+    ref = "";
+  }
+  const path = $('#filepath').val().trim();
+  return {
+    'providerPrefix': providerPrefix, 'repo': repo,
+    'ref': ref, 'path': path, 'pathType': getPathType()
+  };
+}

--- a/binderhub/static/js/src/log.js
+++ b/binderhub/static/js/src/log.js
@@ -1,0 +1,55 @@
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+
+export function setUpLog() {
+  const log = new Terminal({
+    convertEol: true,
+    disableStdin: true
+  });
+
+  const fitAddon = new FitAddon();
+  log.loadAddon(fitAddon);
+  const logMessages = [];
+
+  log.open(document.getElementById('log'), false);
+  fitAddon.fit();
+
+  $(window).resize(function () {
+    fitAddon.fit();
+  });
+
+  const $panelBody = $("div.panel-body");
+  log.show = function () {
+    $('#toggle-logs button.toggle').text('hide');
+    $panelBody.removeClass('hidden');
+  };
+
+  log.hide = function () {
+    $('#toggle-logs button.toggle').text('show');
+    $panelBody.addClass('hidden');
+  };
+
+  log.toggle = function () {
+    if ($panelBody.hasClass('hidden')) {
+      log.show();
+    } else {
+      log.hide();
+    }
+  };
+
+  $('#view-raw-logs').on('click', function (ev) {
+    const blob = new Blob([logMessages.join('')], { type: 'text/plain' });
+    this.href = window.URL.createObjectURL(blob);
+    // Prevent the toggle action from firing
+    ev.stopPropagation();
+  });
+
+  $('#toggle-logs').click(log.toggle);
+
+  log.writeAndStore = function (msg) {
+    logMessages.push(msg);
+    log.write(msg);
+  };
+
+  return [log, fitAddon];
+}

--- a/binderhub/static/js/src/repo.js
+++ b/binderhub/static/js/src/repo.js
@@ -1,5 +1,7 @@
 import { BASE_URL } from "./constants";
 
+let configDict = {};
+
 function setLabels() {
   const provider = $("#provider_prefix").val();
   const text = configDict[provider]["text"];

--- a/binderhub/static/js/src/repo.js
+++ b/binderhub/static/js/src/repo.js
@@ -1,18 +1,5 @@
 import { BASE_URL } from "./constants";
 
-let configDict = {};
-
-export function loadConfig(callback) {
-  const req = new XMLHttpRequest();
-  req.onreadystatechange = function() {
-    if (req.readyState == 4 && req.status == 200)
-      callback(req.responseText)
-  };
-  req.open('GET', BASE_URL + "_config", true);
-  req.send(null);
-}
-
-
 function setLabels() {
   const provider = $("#provider_prefix").val();
   const text = configDict[provider]["text"];

--- a/binderhub/static/js/src/repo.js
+++ b/binderhub/static/js/src/repo.js
@@ -25,6 +25,5 @@ export function updateRepoText() {
     })
   } else {
     setLabels();
-
   }
 }

--- a/binderhub/static/js/src/repo.js
+++ b/binderhub/static/js/src/repo.js
@@ -1,0 +1,43 @@
+import { BASE_URL } from "./constants";
+
+let configDict = {};
+
+export function loadConfig(callback) {
+  const req = new XMLHttpRequest();
+  req.onreadystatechange = function() {
+    if (req.readyState == 4 && req.status == 200)
+      callback(req.responseText)
+  };
+  req.open('GET', BASE_URL + "_config", true);
+  req.send(null);
+}
+
+
+function setLabels() {
+  const provider = $("#provider_prefix").val();
+  const text = configDict[provider]["text"];
+  const tag_text = configDict[provider]["tag_text"];
+  const ref_prop_disabled = configDict[provider]["ref_prop_disabled"];
+  const label_prop_disabled = configDict[provider]["label_prop_disabled"];
+  const placeholder = "HEAD";
+
+  $("#ref").attr('placeholder', placeholder).prop("disabled", ref_prop_disabled);
+  $("label[for=ref]").text(tag_text).prop("disabled", label_prop_disabled);
+  $("#repository").attr('placeholder', text);
+  $("label[for=repository]").text(text);
+}
+
+export function updateRepoText() {
+  if (Object.keys(configDict).length === 0) {
+    const configUrl = BASE_URL + "_config";
+    fetch(configUrl).then(resp => {
+      resp.json().then(data => {
+        configDict = data
+        setLabels();
+      });
+    })
+  } else {
+    setLabels();
+
+  }
+}

--- a/binderhub/static/js/src/urls.js
+++ b/binderhub/static/js/src/urls.js
@@ -2,7 +2,7 @@ import { makeBadgeMarkup } from './badge';
 import { getBuildFormValues } from './form';
 import { BADGE_BASE_URL, BASE_URL } from './constants';
 
- function v2url(providerPrefix, repository, ref, path, pathType) {
+function v2url(providerPrefix, repository, ref, path, pathType) {
   // return a v2 url from a providerPrefix, repository, ref, and (file|url)path
   if (repository.length === 0) {
     // no repo, no url

--- a/binderhub/static/js/src/urls.js
+++ b/binderhub/static/js/src/urls.js
@@ -1,0 +1,53 @@
+import { makeBadgeMarkup } from './badge';
+import { getBuildFormValues } from './form';
+import { BADGE_BASE_URL, BASE_URL } from './constants';
+
+ function v2url(providerPrefix, repository, ref, path, pathType) {
+  // return a v2 url from a providerPrefix, repository, ref, and (file|url)path
+  if (repository.length === 0) {
+    // no repo, no url
+    return null;
+  }
+  let url;
+  if (BADGE_BASE_URL) {
+    url = BADGE_BASE_URL + 'v2/' + providerPrefix + '/' + repository + '/' + ref;
+  }
+  else {
+    url = window.location.origin + BASE_URL + 'v2/' + providerPrefix + '/' + repository + '/' + ref;
+  }
+  if (path && path.length > 0) {
+    // encode the path, it will be decoded in loadingMain
+    url = url + '?' + pathType + 'path=' + encodeURIComponent(path);
+  }
+  return url;
+}
+
+export function updateUrls(formValues) {
+  if (typeof formValues === "undefined") {
+    formValues = getBuildFormValues();
+  }
+  const url = v2url(
+    formValues.providerPrefix,
+    formValues.repo,
+    formValues.ref,
+    formValues.path,
+    formValues.pathType
+  );
+
+  if ((url || '').trim().length > 0) {
+    // update URLs and links (badges, etc.)
+    $("#badge-link").attr('href', url);
+    $('#basic-url-snippet').text(url);
+    $('#markdown-badge-snippet').text(
+      makeBadgeMarkup(BADGE_BASE_URL, BASE_URL, url, 'markdown')
+    );
+    $('#rst-badge-snippet').text(
+      makeBadgeMarkup(BADGE_BASE_URL, BASE_URL, url, 'rst')
+    );
+  } else {
+    ['#basic-url-snippet', '#markdown-badge-snippet', '#rst-badge-snippet'].map(function (item) {
+      const el = $(item);
+      el.text(el.attr('data-default'));
+    });
+  }
+}

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -13,7 +13,7 @@ from kubernetes import client
 from tornado.httputil import url_concat
 from tornado.queues import Queue
 
-from binderhub.build import KubernetesBuildExecutor, ProgressEvent
+from binderhub.build import BuildExecutor, KubernetesBuildExecutor, ProgressEvent
 from binderhub.build_local import LocalRepo2dockerBuild, ProcessTerminated, _execute_cmd
 
 from .utils import async_requests
@@ -415,3 +415,21 @@ def test_execute_cmd_break():
             lines.append(line)
     assert lines == ["1\n"]
     assert str(exc.value) == f"ProcessTerminated: {cmd}"
+
+
+def test_extra_r2d_options():
+    bex = BuildExecutor()
+    bex.repo2docker_extra_args = ["--repo-dir=/srv/repo"]
+    bex.image_name = "test:test"
+    bex.ref = "main"
+
+    assert bex.get_r2d_cmd_options() == [
+        "--ref=main",
+        "--image=test:test",
+        "--no-clean",
+        "--no-run",
+        "--json-logs",
+        "--user-name=jovyan",
+        "--user-id=1000",
+        "--repo-dir=/srv/repo",
+    ]

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -40,7 +40,7 @@ google-auth==2.23.2
     #   google-api-core
     #   google-cloud-core
     #   kubernetes
-google-cloud-appengine-logging==1.3.1
+google-cloud-appengine-logging==1.3.2
     # via google-cloud-logging
 google-cloud-audit-log==0.2.5
     # via google-cloud-logging
@@ -54,7 +54,7 @@ googleapis-common-protos[grpc]==1.60.0
     #   google-cloud-audit-log
     #   grpc-google-iam-v1
     #   grpcio-status
-greenlet==2.0.2
+greenlet==3.0.0
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-logging
@@ -98,7 +98,7 @@ oauthlib==3.2.2
     # via
     #   jupyterhub
     #   requests-oauthlib
-packaging==23.1
+packaging==23.2
     # via
     #   docker
     #   jupyterhub
@@ -190,7 +190,7 @@ typing-extensions==4.8.0
     # via
     #   alembic
     #   sqlalchemy
-urllib3==2.0.5
+urllib3==2.0.6
     # via
     #   docker
     #   kubernetes


### PR DESCRIPTION
- Follows the plan laid out in https://github.com/jupyterhub/binderhub/issues/777
- Only non-trivial move is to cleanup the `_config` call to use the more modern 'fetch' API rather than the older XMLHttpRequest API

Fixes https://github.com/jupyterhub/binderhub/issues/777